### PR TITLE
Added nodejs10.x as a valid RUNTIME for AWS Lambda

### DIFF
--- a/packages/language-server/src/language-service/services/completion/constants.ts
+++ b/packages/language-server/src/language-service/services/completion/constants.ts
@@ -1,4 +1,5 @@
 export const RUNTIMES = [
+	"nodejs10.x",
 	"nodejs8.10",
 	"nodejs6.10",
 	"python3.6",


### PR DESCRIPTION
`nodejs10.x` is now a valid RUNTIME for AWS Lambda; this is adding this to the list of RUNTIMES available.