### PR TITLE
Rename tenant to org

### DIFF
--- a/packages/language-server/src/language-service/services/completion/__tests__/__snapshots__/completion-sls.test.ts.snap
+++ b/packages/language-server/src/language-service/services/completion/__tests__/__snapshots__/completion-sls.test.ts.snap
@@ -854,12 +854,12 @@ Object {
         "documentType": "SERVERLESS_FRAMEWORK",
       },
       "documentation": "",
-      "insertText": "tenant: $1",
+      "insertText": "org: $1",
       "insertTextFormat": 2,
       "kind": 10,
-      "label": "tenant",
+      "label": "org",
       "textEdit": Object {
-        "newText": "tenant: $1",
+        "newText": "org: $1",
         "range": Object {
           "end": Object {
             "character": 4,

--- a/packages/serverless-framework-schema/src/index.ts
+++ b/packages/serverless-framework-schema/src/index.ts
@@ -63,7 +63,7 @@ const buildSchema = async () => {
 			app: {
 				type: "string"
 			},
-			tenant: {
+			org: {
 				type: "string"
 			},
 			service: {


### PR DESCRIPTION
Per https://github.com/serverless/serverless/pull/6655, `tenant` should rename to `org`