### PR TITLE
Add provider.variableSyntax

### DIFF
--- a/packages/serverless-framework-schema/json/aws/provider/provider.json
+++ b/packages/serverless-framework-schema/json/aws/provider/provider.json
@@ -290,7 +290,12 @@
                     "description": "Optional configuration which specifies if Websockets logs are used"
                 }
             }
-        }
+        },
+		"variableSyntax": {
+            "type": "string",
+            "description": "A custom syntax to overwrite the default ${xxx} syntax to resolve conflicts with some CloudFormation functionality",
+            "default": "\\${([ ~:a-zA-Z0-9._@\\'\",\\-\\/\\(\\)]+?)}"
+		}
     },
     "required": [
         "name"


### PR DESCRIPTION
Serverless support custom variable syntax to resolve the conflict with CloudFormation.

See: https://serverless.com/framework/docs/providers/aws/guide/variables#using-custom-variable-syntax

Note: I have not tested it yet, feel free to change it if there was an error.