### PR TITLE
Fixes serverless deploymentBucket property name as required when it is not

### DIFF
--- a/packages/serverless-framework-schema/json/aws/provider/provider.json
+++ b/packages/serverless-framework-schema/json/aws/provider/provider.json
@@ -81,10 +81,7 @@
                     "$ref": "#/definitions/common:tags",
                     "description": "Tags that will be added to each of the deployment resources"
                 }
-            },
-            "required": [
-                "name"
-            ]
+            }
         },
         "deploymentPrefix": {
             "type": "string",


### PR DESCRIPTION
The deploymentBucket property does not need to have name as required in order to be deployed. Some times we just want to set encryption for the deployment bucket and leave the default name.

    provider:
      name: aws
      runtime: python3.7
      stage: prod
      deploymentBucket:
        serverSideEncryption: AES256
