### PR TITLE
Add missing property `existing`

### DIFF
--- a/packages/serverless-framework-schema/json/aws/functions/events/cognitoUserPool.json
+++ b/packages/serverless-framework-schema/json/aws/functions/events/cognitoUserPool.json
@@ -13,7 +13,11 @@
                 "trigger": {
                     "type": "string",
                     "default": "PreSignUp"
-                }
+                },
+				"existing":{
+					"type":"boolean",
+					"default":false
+				},
             },
             "require": [
                 "logGroup",


### PR DESCRIPTION
Link to property `existing` in serverless documentation: https://serverless.com/framework/docs/providers/aws/events/cognito-user-pool#using-existing-pool