### PR TITLE
add roleManagedExternally option for logs.restApi

### DIFF
--- a/packages/serverless-framework-schema/json/aws/provider/provider.json
+++ b/packages/serverless-framework-schema/json/aws/provider/provider.json
@@ -337,9 +337,14 @@
 								},
 								"role": {
 									"type": "string",
-									"description": "Optional IAM role for ApiGateway to use when managing CloudWatch Logs",
+									"description": "Existing IAM role for ApiGateway to use when managing CloudWatch Logs. If 'role' is not configured, a new role is automatically created.",
 									"default": "arn:aws:iam::XXXXXX:role/role"
-								}
+                                },
+                                "roleManagedExternally": {
+                                    "type": "boolean",
+                                    "description": "Specifies whether the ApiGateway CloudWatch Logs role setting is not managed by Serverless. Defaults to false.",
+                                    "default": false
+                                }
                             }
                         }
                     ]


### PR DESCRIPTION
I've added a new setting to serverless repo via pull request (already merged to master), called roleManagedExternally. See https://github.com/serverless/serverless/pull/7333 for details.

This is going to be made available in the next v1.64 serverless package, so merging it in the VSCode plugin would be nice.

Also updated the description for role (since I changed it in the same pull request to be a bit more clear).

Documentation already available at https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/