### PR TITLE
Added "PATCH" as valid method for HTTP events

### DIFF
--- a/packages/serverless-framework-schema/json/aws/functions/events/http.json
+++ b/packages/serverless-framework-schema/json/aws/functions/events/http.json
@@ -162,6 +162,7 @@
                             "enum": [
                                 "get",
                                 "head",
+                                "patch",
                                 "post",
                                 "put",
                                 "delete",
@@ -171,6 +172,7 @@
                                 "any",
                                 "GET",
                                 "HEAD",
+                                "PATCH",
                                 "POST",
                                 "PUT",
                                 "DELETE",

--- a/packages/serverless-framework-schema/json/aws/functions/events/httpApi.json
+++ b/packages/serverless-framework-schema/json/aws/functions/events/httpApi.json
@@ -15,6 +15,7 @@
                             "enum": [
                                 "get",
                                 "head",
+                                "patch",
                                 "post",
                                 "put",
                                 "delete",
@@ -24,6 +25,7 @@
                                 "any",
                                 "GET",
                                 "HEAD",
+                                "PATCH",
                                 "POST",
                                 "PUT",
                                 "DELETE",

--- a/packages/serverless-framework-schema/schema.json
+++ b/packages/serverless-framework-schema/schema.json
@@ -624,6 +624,7 @@
                   "enum": [
                     "get",
                     "head",
+                    "patch",
                     "post",
                     "put",
                     "delete",
@@ -633,6 +634,7 @@
                     "any",
                     "GET",
                     "HEAD",
+                    "PATCH",
                     "POST",
                     "PUT",
                     "DELETE",


### PR DESCRIPTION
This pull request resolves a bug where the plugin incorrectly reports "PATCH" as an invalid value for HTTP methods.