### PR TITLE
AuthorizerId is a valid alternative to name / arn

### DIFF
--- a/packages/serverless-framework-schema/json/aws/common/authorizer.json
+++ b/packages/serverless-framework-schema/json/aws/common/authorizer.json
@@ -17,7 +17,7 @@
                 },
 				"authorizerId": {
                     "type": "string",
-                    "description": "Can be used instead of name or arn to reference a an authorizer defined elsewhere",
+                    "description": "Can be used instead of name or arn to reference an authorizer defined elsewhere",
                     "default": "AuthorizerID"
                 },
                 "resultTtlInSeconds": {
@@ -49,7 +49,7 @@
                     "enum": [
                         "token",
                         "request",
-						"cognito_user_pools"
+                        "cognito_user_pools"
                     ],
                     "default": "token",
                     "description": "token or request. Determines input to the authorier function, called with the auth token or the entire request event. Defaults to token"

--- a/packages/serverless-framework-schema/json/aws/common/authorizer.json
+++ b/packages/serverless-framework-schema/json/aws/common/authorizer.json
@@ -15,6 +15,11 @@
                     "description": "Can be used instead of name to reference a function outside of service",
                     "default": "xxx:xxx:Lambda-Name"
                 },
+				"authorizerId": {
+                    "type": "string",
+                    "description": "Can be used instead of name or arn to reference a an authorizer defined elsewhere",
+                    "default": "AuthorizerID"
+                },
                 "resultTtlInSeconds": {
                     "type": "number",
                     "default": 0
@@ -43,7 +48,8 @@
                     "type": "string",
                     "enum": [
                         "token",
-                        "request"
+                        "request",
+						"cognito_user_pools"
                     ],
                     "default": "token",
                     "description": "token or request. Determines input to the authorier function, called with the auth token or the entire request event. Defaults to token"
@@ -58,6 +64,11 @@
                 {
                     "required": [
                         "arn"
+                    ]
+                },
+                {
+                    "required": [
+                        "authorizerId"
                     ]
                 }
             ]


### PR DESCRIPTION
(Also, the type can be 'cognito_user_pools')

See: https://github.com/serverless/serverless/blob/19012a9068357f307693823bc56bb2ce1d881a64/docs/providers/aws/events/apigateway.md#share-authorizer