### PR TITLE
fix json schema for lambda layers packages -> package

### DIFF
--- a/packages/serverless-framework-schema/json/aws/layers.json
+++ b/packages/serverless-framework-schema/json/aws/layers.json
@@ -66,7 +66,7 @@
                 },
                 {
                     "required": [
-                        "packages"
+                        "package"
                     ]
                 }
             ]

--- a/packages/serverless-framework-schema/schema.json
+++ b/packages/serverless-framework-schema/schema.json
@@ -1289,7 +1289,7 @@
             },
             {
               "required": [
-                "packages"
+                "package"
               ]
             }
           ]


### PR DESCRIPTION
Update to the json schema for Severless lambda layers. Typo, `packages` should be `package` 

https://www.serverless.com/framework/docs/providers/aws/guide/layers/