### PR TITLE
Adds new dotnetcore3.1 runtime support

### DIFF
--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -13,6 +13,7 @@
         "java8",
         "go1.x",
         "dotnetcore2.1",
+		"dotnetcore3.1",
         "provided"
     ],
     "default": "nodejs10.x"


### PR DESCRIPTION
This PR add new runtime support for dotnet core 3.1 as published here https://aws.amazon.com/es/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/

I would be glad if you can add this, currently I'm working with this runtime and always displays as an error in the script.