### PR TITLE
Cloudwatch Event should not require `input`, `inputPath`, or `inputTasnformer`

### DIFF
--- a/packages/serverless-framework-schema/schema.json
+++ b/packages/serverless-framework-schema/schema.json
@@ -388,23 +388,6 @@
               "type": "object"
             }
           },
-          "oneOf": [
-            {
-              "required": [
-                "input"
-              ]
-            },
-            {
-              "required": [
-                "inputPath"
-              ]
-            },
-            {
-              "required": [
-                "inputTransformer"
-              ]
-            }
-          ],
           "required": [
             "event"
           ]


### PR DESCRIPTION
Should fix #99