### PR TITLE
add `aws:kms` as supported server side encryption value for deployment buckets

### DIFF
--- a/packages/serverless-framework-schema/schema.json
+++ b/packages/serverless-framework-schema/schema.json
@@ -1431,7 +1431,8 @@
             "serverSideEncryption": {
               "type": "string",
               "enum": [
-                "AES256"
+                "AES256",
+                "aws:kms"
               ],
               "description": "when using server-side encryption"
             },


### PR DESCRIPTION
Should fix #104 