### PR TITLE
Adds python3.9 as a valid value for provider.runtime for sls framework

### DIFF
--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -5,6 +5,7 @@
         "nodejs12.x",
         "nodejs10.x",
         "nodejs8.10",
+        "python3.9",
         "python3.8",
         "python3.6",
         "python3.7",


### PR DESCRIPTION
This PR fixes an issue where the plugin was incorrectly reporting python3.9 as an invalid value for `provider.runtime` when using Serverless Framework.