### PR TITLE
Add support for VPC nullification

### DIFF
--- a/packages/serverless-framework-schema/json/aws/common/vpc.json
+++ b/packages/serverless-framework-schema/json/aws/common/vpc.json
@@ -1,19 +1,34 @@
 {
-    "type": "object",
-    "description": "Optional VPC. But if you use VPC then both subproperties (securityGroupIds and subnetIds) are required",
-    "additionalProperties": false,
-    "properties": {
-        "securityGroupIds": {
-            "type": "array",
-            "items": {
-                "type": "string"
+    "description": "Optional VPC. If you use VPC then both subproperties (securityGroupIds and subnetIds) are required. Can be set to ~ to specify no VPC.",
+    "oneOf": [
+        {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "securityGroupIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subnetIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
             }
         },
-        "subnetIds": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
+        {
+            "type": "null"
+        },
+        {
+            "type": "boolean",
+            "enum": [false]
+        },
+        {
+            "type": "string",
+            "enum": [""]
         }
-    }
+    ]
 }


### PR DESCRIPTION
VPCs may be explicitly disabled via YAML null values (empty line, `~`, or `null`) or `false` as of https://github.com/serverless/serverless/pull/10060. This change allows these new values to be set without any errors appearing.

`~` and `null`, which should be `null` values as per yaml spec (https://yaml.org/spec/1.2.2/) seem to be recognised as `string` types with an empty string as value, so there's more options than expected for the allowed values.

Only the function-level VPC logic was changed in serverless but this ability to specify no VPC should be valid for both the function-level and provider-level VPC configs. This means that the shared use of this configuration type in this repo should still be valid.