### PR TITLE
feat: Add Active and PassThrough to ServerLess tracing

### DIFF
--- a/packages/serverless-framework-schema/json/aws/provider/provider.json
+++ b/packages/serverless-framework-schema/json/aws/provider/provider.json
@@ -311,8 +311,19 @@
                     "default": true
                 },
                 "lambda": {
-                    "type": "boolean",
-                    "description": "Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'"
+                    "description": "Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'",
+                    "oneOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "type": "string",
+                            "enum": [
+                                "Active",
+                                "PassThrough"
+                            ]
+                        }
+                    ]
                 }
             },
             "required": [


### PR DESCRIPTION
Adds enum options to `lambda` tracing in the Serverless Framework's `provider.json` to match documented type.

Serverless documentation on [AWS - Functions
](https://github.com/serverless/serverless/blob/master/docs/providers/aws/guide/functions.md#aws-x-ray-tracing)
```
lambda: true # optional, enables tracing for all functions (can be true (true equals 'Active') 'Active' or 'PassThrough')
```