### PR TITLE
add nodejs16.x runtime

### DIFF
--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -1,6 +1,7 @@
 {
     "type": "string",
     "enum": [
+        "nodejs16.x",
         "nodejs14.x",
         "nodejs12.x",
         "nodejs10.x",


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/