### PR TITLE
add support for node 18 runtime

### DIFF
--- a/packages/language-server/src/language-service/services/completion/constants.ts
+++ b/packages/language-server/src/language-service/services/completion/constants.ts
@@ -1,4 +1,5 @@
 export const RUNTIMES = [
+	"nodejs18.x",
 	"nodejs16.x",
 	"nodejs14.x",
 	"nodejs12.x",

--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -1,6 +1,7 @@
 {
     "type": "string",
     "enum": [
+        "nodejs18.x",
         "nodejs16.x",
         "nodejs14.x",
         "nodejs12.x",


### PR DESCRIPTION
Updating to support the latest added runtime:
https://github.com/serverless/serverless/releases