### PR TITLE
Add nodejs18.x to runtime options for AWS

### DIFF
--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -1,6 +1,7 @@
 {
     "type": "string",
     "enum": [
+		"nodejs18.x",
         "nodejs16.x",
         "nodejs14.x",
         "nodejs12.x",


### PR DESCRIPTION
AWS Lambda supports `nodejs18.x` - reference supported AWS Lambda runtimes [here](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)