### PR TITLE
include cfn-lint informational checks by default

### DIFF
--- a/packages/language-server/src/language-service/services/validation/index.ts
+++ b/packages/language-server/src/language-service/services/validation/index.ts
@@ -105,6 +105,7 @@ export class YAMLValidation {
 		const args = ["--format", "json"]
 		const filePath = Files.uriToFilePath(textDocument.uri)
 		const fileName = textDocument.uri
+		const cfnLintPath = this.settings.path || "cfn-lint"
 
 		this.settings.ignoreRules.map(rule => {
 			args.push("--ignore-checks", rule)
@@ -118,11 +119,15 @@ export class YAMLValidation {
 			args.push("--override-spec", this.settings.overrideSpecPath)
 		}
 
+		if (!(cfnLintPath.includes(' --include-checks ') || cfnLintPath.includes(' -c '))) {
+			args.push("--include-checks", "I")
+		}
+
 		args.push("--", filePath)
 
 		this.inProgressMap[fileName] = true
 
-		const child = spawn(this.settings.path || "cfn-lint", args, {
+		const child = spawn(cfnLintPath, args, {
 			cwd: this.workspaceRoot
 		})
 


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-lint/#info-rules

As with https://github.com/aws-cloudformation/cfn-lint-visual-studio-code/pull/223, editors seem like a great place to start surfacing informational checks by default since they are easily ignored and the exit code doesn't really matter

---

Have not personally tested these changes, but informational severity looks already mapped here:
https://github.com/threadheap/serverless-ide-vscode/blob/52279a31bdf599928812e04fbe9d0ee79684e610/packages/language-server/src/language-service/services/validation/index.ts#L27-L39