### PR TITLE
Add OriginAccessControlId & S3OriginConfig fields to cloudfront origin schema

### DIFF
--- a/packages/serverless-framework-schema/json/aws/functions/events/cloudFront.json
+++ b/packages/serverless-framework-schema/json/aws/functions/events/cloudFront.json
@@ -29,10 +29,23 @@
                                 "DomainName": {
                                     "type": "string"
                                 },
+								"OriginAccessControlId" {
+									"oneOf": [
+										{
+											"type": "string"
+										},
+										{
+											"type": "object"
+										}
+									]
+								},
                                 "OriginPath": {
                                     "type": "string"
                                 },
                                 "CustomOriginConfig": {
+                                    "type": "object"
+                                },
+                                "S3OriginConfig": {
                                     "type": "object"
                                 }
                             }


### PR DESCRIPTION
The schema for CloudFront origins seems to be missing these two possible fields. `S3OriginConfig` has been there for a while. `OriginAccessControlId` is new, and [just landed](https://github.com/serverless/serverless/pull/11855) in Serverless 3.29.0.