### PR TITLE
feat: add python 3.10 and 3.11 to supported runtimes

### DIFF
--- a/packages/language-server/src/language-service/services/completion/constants.ts
+++ b/packages/language-server/src/language-service/services/completion/constants.ts
@@ -5,6 +5,8 @@ export const RUNTIMES = [
 	"nodejs12.x",
 	"nodejs10.x",
 	"nodejs8.10",
+	"python3.11",
+	"python3.10",
 	"python3.9",
 	"python3.8",
 	"python3.6",

--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -7,6 +7,7 @@
         "nodejs12.x",
         "nodejs10.x",
         "nodejs8.10",
+        "python3.11",
 		"python3.10",
         "python3.9",
         "python3.8",

--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -7,6 +7,7 @@
         "nodejs12.x",
         "nodejs10.x",
         "nodejs8.10",
+		"python3.10",
         "python3.9",
         "python3.8",
         "python3.6",

--- a/packages/serverless-framework-schema/schema.json
+++ b/packages/serverless-framework-schema/schema.json
@@ -203,6 +203,8 @@
         "nodejs12.x",
         "nodejs10.x",
         "nodejs8.10",
+        "python.3.11",
+	      "python3.10",
         "python3.9",
         "python3.8",
         "python3.6",


### PR DESCRIPTION
Blocked by https://github.com/serverless/serverless/pull/11922

resolves: #207 