### PR TITLE
Added support for new nodejs20.x runtime on AWS

### DIFF
--- a/packages/language-server/src/language-service/services/completion/constants.ts
+++ b/packages/language-server/src/language-service/services/completion/constants.ts
@@ -1,4 +1,5 @@
 export const RUNTIMES = [
+	"nodejs20.x",
 	"nodejs18.x",
 	"nodejs16.x",
 	"nodejs14.x",

--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -1,6 +1,7 @@
 {
     "type": "string",
     "enum": [
+        "nodejs20.x",
         "nodejs18.x",
         "nodejs16.x",
         "nodejs14.x",


### PR DESCRIPTION
Added support for new "nodejs20.x" AWS lambda runtime. This will remove the "Value is not accepted." error from serverless.yml when nodejs20.x runtime is added.