### PR TITLE
Inclusion of NodeJS 22 runtime

### DIFF
--- a/packages/language-server/src/language-service/services/completion/constants.ts
+++ b/packages/language-server/src/language-service/services/completion/constants.ts
@@ -1,4 +1,5 @@
 export const RUNTIMES = [
+	"nodejs22.x",
 	"nodejs20.x",
 	"nodejs18.x",
 	"nodejs16.x",

--- a/packages/serverless-framework-schema/json/aws/common/runtime.json
+++ b/packages/serverless-framework-schema/json/aws/common/runtime.json
@@ -1,6 +1,7 @@
 {
     "type": "string",
     "enum": [
+        "nodejs22.x",
         "nodejs20.x",
         "nodejs18.x",
         "nodejs16.x",


### PR DESCRIPTION
On November 21th, Node.js 22 runtime became available in AWS Lambda. [Ref. 1](https://aws.amazon.com/pt/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/)

Also, on November 27th, the release of version v4.4.13 included the Node.js 22 runtime on Serverless Framework. [Ref.2](https://github.com/serverless/serverless/releases/tag/v4.4.13)

The proposed changes are to added support for the `nodejs22.x` runtime on extension, otherwise a warning will be prompt on screen and this version will not be listed as a valid value.

![image](https://github.com/user-attachments/assets/82440bb1-efb0-407e-9ede-d80b445c97e1)
